### PR TITLE
Better Docker JVM

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,17 +15,18 @@ jobs:
           distribution: 'adopt'
       - name: Compile with Maven
         run: mvn compile
+      - name: Build Artifacts
+        run: |
+          mkdir staging
+          mvn package
+          cp target/*.jar staging
       - name: Build Docker Image
         run: docker build -t semimage .
       - name: Run image
         run: docker run --name semcontainer -d semimage
       - name: view logs
         run: docker logs semcontainer
-      - name: Build Artifacts
-        run: |
-          mkdir staging
-          mvn package
-          cp target/*.jar staging
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-FROM openjdk:latest
-COPY ./target/classes/com /tmp/com
-WORKDIR /tmp
-RUN curl --output world-db.zip https://downloads.mysql.com/docs/world-db.zip
-ENTRYPOINT ["java", "com.napier.sem.Main"]
+FROM openjdk:17-jdk-alpine
+COPY target/sm-group-project-0.1-jar-with-dependencies.jar app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
The DockerJVM now runs with the jar-with-dependencies.jar file, which intellij doesn't automatically generate. Use the mvn install command instead.